### PR TITLE
✨ [Feat] 네이버 스포츠 API 크롤러 서비스 구현 #6

### DIFF
--- a/app/services/crawler/__init__.py
+++ b/app/services/crawler/__init__.py
@@ -1,0 +1,14 @@
+from app.services.crawler.client import NaverSportClient
+from app.services.crawler.parser import PreviewParser, ScheduleParser, GameLineup, LineupPlayer
+from app.services.crawler.schedule import ScheduleCrawlerService
+from app.services.crawler.lineup import LineupCrawlerService
+
+__all__ = [
+    "NaverSportClient",
+    "PreviewParser",
+    "ScheduleParser",
+    "GameLineup",
+    "LineupPlayer",
+    "LineupCrawlerService",
+    "ScheduleCrawlerService",
+]

--- a/app/services/crawler/client.py
+++ b/app/services/crawler/client.py
@@ -1,0 +1,50 @@
+import httpx
+from typing import Any
+from datetime import date
+
+class NaverSportClient:
+    BASE_URL = "https://api-gw.sports.naver.com"
+
+    DEFAULT_HEADERS = {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
+        "Referer": "https://m.sports.naver.com",
+        "Origin": "https://m.sports.naver.com",
+    }
+
+    def __init__(self, timeout: float = 10.0):
+        self.timeout = timeout
+
+    def get_game_preview(self, game_id: str) -> dict[str, Any] | None:
+        url = f"{self.BASE_URL}/schedule/games/{game_id}/preview"
+
+        try:
+            with httpx.Client(timeout=self.timeout) as client:
+                response = client.get(url, headers=self.DEFAULT_HEADERS)
+                response.raise_for_status()
+                return response.json()
+        except httpx.HTTPStatusError as e:
+            return None
+        except httpx.RequestError as e:
+            return None
+
+    def get_schedule(self, target_date: date | None = None) -> dict[str, Any] | None:
+        if target_date is None:
+            target_date = date.today()
+
+        date_str = target_date.strftime("%Y-%m-%d")
+        url = f"{self.BASE_URL}/schedule/calendar"
+        params = {
+            "upperCategoryId": "kbaseball",
+            "categoryIds": "kbo,kbaseballetc,premier12,apbc",
+            "date": date_str,
+        }
+
+        try:
+            with httpx.Client(timeout=self.timeout) as client:
+                response = client.get(url, headers=self.DEFAULT_HEADERS, params=params)
+                response.raise_for_status()
+                return response.json()
+        except httpx.HTTPStatusError:
+            return None
+        except httpx.RequestError:
+            return None

--- a/app/services/crawler/lineup.py
+++ b/app/services/crawler/lineup.py
@@ -1,0 +1,51 @@
+import logging
+from app.services.crawler.client import NaverSportClient
+from app.services.crawler.parser import PreviewParser, GameLineup
+
+logger = logging.getLogger(__name__)
+
+class LineupCrawlerService:
+    def __init__(
+            self,
+            client: NaverSportClient | None = None,
+            parser: PreviewParser | None = None,
+    ):
+
+        self.client = client or NaverSportClient()
+        self.parser = parser or PreviewParser()
+
+    def crawl_lineup(self, game_id: str) -> GameLineup | None:
+        """단일 게임 라인업 크롤링"""
+        logger.info(f"게임 라인업 크롤링 시작 : {game_id}")
+
+        data = self.client.get_game_preview(game_id)
+        if data is None:
+            logger.error(f"게임 프리뷰 조회 실패 : {game_id}")
+            return None
+
+        lineup = self.parser.parse(data)
+        if lineup is None:
+            logger.warning(f"라인업 파싱 실패 또는 미발표 : {game_id}")
+            return None
+
+        logger.info(
+            f"라인업 크롤링 완료 : {game_id} "
+            f"(홈 : {len(lineup.home_players)}명, 원정 : {len(lineup.away_players)}명)"
+        )
+        return lineup
+
+    def crawl_lineups(self, game_ids: list[str]) -> list[GameLineup]:
+        """여러 게임 라인업 크롤링"""
+        results = []
+
+        for game_id in game_ids:
+            try:
+                lineup = self.crawl_lineup(game_id)
+                if lineup:
+                    results.append(lineup)
+            except Exception as e:
+                logger.exception(f"게임 처리 중 예외 발생 : {game_id}")
+                continue
+
+        logger.info(f"전체 크롤링 완료 : {len(results)} / {len(game_ids)} 게임 라인업 크롤링 성공")
+        return results

--- a/app/services/crawler/parser.py
+++ b/app/services/crawler/parser.py
@@ -1,0 +1,85 @@
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+KBO_GAME_ID_LENGTH = 17
+
+@dataclass
+class LineupPlayer:
+    name: str
+    bat_order: int
+    position: str
+    back_number: str | None = None
+    bats_throws: str | None = None
+
+@dataclass
+class GameLineup:
+    home_team_code: str
+    away_team_code: str
+    home_players: list[LineupPlayer]
+    away_players: list[LineupPlayer]
+
+class PreviewParser:
+
+    def parse(self, data: dict[str, Any]) -> GameLineup | None:
+        if not self._is_valid_response(data):
+            return None
+
+        preview_data = data["result"]["previewData"]
+        game_info = preview_data["gameInfo"]
+
+        home_lineup = preview_data.get("homeTeamLineUp", {}).get("fullLineUp", [])
+        away_lineup = preview_data.get("awayTeamLineUp", {}).get("fullLineUp", [])
+
+        if not self._has_lineup(home_lineup) or not self._has_lineup(away_lineup):
+            return None
+
+        return GameLineup(
+            home_team_code=game_info["hCode"],
+            away_team_code=game_info["aCode"],
+            home_players=self._parse_players(home_lineup),
+            away_players=self._parse_players(away_lineup),
+        )
+
+    def _is_valid_response(self, data: dict) -> bool:
+        return data.get("code") == 200 and data.get("success") is True
+
+    def _has_lineup(self, lineup: list[dict]) -> bool:
+        return any("batorder" in player for player in lineup)
+
+    def _parse_players(self, lineup: list[dict]) -> list[LineupPlayer]:
+        players = []
+
+        for player_data in lineup:
+            if "batorder" not in player_data:
+                continue
+
+            player = LineupPlayer(
+                name=player_data["playerName"],
+                bat_order=int(player_data["batorder"]),
+                position=player_data.get("positionName", ""),
+                back_number=player_data.get("backnum", ""),
+                bats_throws=player_data.get("batsThrows"),
+            )
+            players.append(player)
+
+        return players
+
+class ScheduleParser:
+
+    def parse_today_game_ids(self, data: dict[str, Any]) -> list[str]:
+        if not self._is_valid_response(data):
+            return []
+
+        result = data["result"]
+        today = result["today"]
+
+        for date_node in result.get("dates", []):
+            if date_node.get("ymd") == today:
+                game_ids = date_node.get("gameIds", [])
+                return [gid for gid in game_ids if len(gid) == KBO_GAME_ID_LENGTH]
+
+        return []
+
+    def _is_valid_response(self, data: dict[str, Any]) -> bool:
+        return data.get("code") == 200 and data.get("success") is True

--- a/app/services/crawler/schedule.py
+++ b/app/services/crawler/schedule.py
@@ -1,0 +1,28 @@
+import logging
+from app.services.crawler.client import NaverSportClient
+from app.services.crawler.parser import ScheduleParser
+
+logger = logging.getLogger(__name__)
+
+class ScheduleCrawlerService:
+
+    def __init__(
+        self,
+        client: NaverSportClient | None = None,
+        parser: ScheduleParser | None = None,
+    ):
+        self.client = client or NaverSportClient()
+        self.parser = parser or ScheduleParser()
+
+    def get_today_game_ids(self) -> list[str]:
+        logger.info("오늘 경기 일정 크롤링 시작")
+
+        data = self.client.get_schedule()
+        if data is None:
+            logger.error("스케줄 조회 실패")
+            return []
+
+        game_ids = self.parser.parse_today_game_ids(data)
+        logger.info(f"오늘 경기 {len(game_ids)}개 발견 : {game_ids}")
+
+        return game_ids


### PR DESCRIPTION
  ### 변경 사항
  - `NaverSportClient`: 네이버 스포츠 API 호출 클라이언트
  - `PreviewParser`, `ScheduleParser`: API 응답 파싱
  - `LineupCrawlerService`: 라인업 크롤링
  - `ScheduleCrawlerService`: 오늘 경기 일정 크롤링

  ### API 엔드포인트
  - 일정 조회: `GET /schedule/calendar`
  - 라인업 조회: `GET /schedule/games/{game_id}/preview`