### PR TITLE
✨ [Feat] 크롤링 API 및 팀 정보 최신화 기능 구현 #10

### DIFF
--- a/app/infrastructure/notion/client.py
+++ b/app/infrastructure/notion/client.py
@@ -1,15 +1,28 @@
+import httpx
 from notion_client import Client
 from notion_client.errors import APIResponseError
 
 from app.config import settings
 
+
 class NotionClientError(Exception):
     pass
 
+
 class NotionClient:
+    BASE_URL = "https://api.notion.com/v1"
+    NOTION_VERSION = "2022-06-28"
 
     def __init__(self, api_key: str | None = None):
-        self._client = Client(auth=api_key or settings.notion_api_key)
+        self._api_key = api_key or settings.notion_api_key
+        self._client = Client(auth=self._api_key)
+
+    def _get_headers(self) -> dict:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Notion-Version": self.NOTION_VERSION,
+            "Content-Type": "application/json",
+        }
 
     def query_database(
         self,
@@ -18,14 +31,18 @@ class NotionClient:
         sorts: list[dict] | None = None,
     ) -> list[dict]:
         try:
-            response = self._client.databases.query(
-                database_id=database_id,
-                filter=filter,
-                sorts=sorts,
-            )
-            return response.get("results", [])
-        except APIResponseError as e:
-            raise NotionClientError(f"Database query failed: {e.message}") from e
+            body = {}
+            if filter:
+                body["filter"] = filter
+            if sorts:
+                body["sorts"] = sorts
+
+            url = f"{self.BASE_URL}/databases/{database_id}/query"
+            response = httpx.post(url, headers=self._get_headers(), json=body)
+            response.raise_for_status()
+            return response.json().get("results", [])
+        except httpx.HTTPStatusError as e:
+            raise NotionClientError(f"Database query failed: {e.response.text}") from e
 
     def create_page(self, database_id: str, properties: dict) -> dict:
         try:
@@ -34,7 +51,7 @@ class NotionClient:
                 properties=properties,
             )
         except APIResponseError as e:
-            raise NotionClientError(f"Page create failed: {e.message}") from e
+            raise NotionClientError(f"Page create failed: {str(e)}") from e
 
     def update_page(self, page_id: str, properties: dict) -> dict:
         try:
@@ -43,7 +60,7 @@ class NotionClient:
                 properties=properties,
             )
         except APIResponseError as e:
-            raise NotionClientError(f"Page update failed: {e.message}") from e
+            raise NotionClientError(f"Page update failed: {str(e)}") from e
 
     def archive_page(self, page_id: str) -> dict:
         try:
@@ -52,4 +69,4 @@ class NotionClient:
                 archived=True,
             )
         except APIResponseError as e:
-            raise NotionClientError(f"Page archive failed: {e.message}") from e
+            raise NotionClientError(f"Page archive failed: {str(e)}") from e

--- a/app/infrastructure/notion/mappers/cheersong_mapper.py
+++ b/app/infrastructure/notion/mappers/cheersong_mapper.py
@@ -3,26 +3,26 @@ from app.infrastructure.notion.mappers.base import BaseMapper
 
 class CheerSongMapper(BaseMapper[CheerSong]):
 
-    PROP_PLAYER_CODE = "선수코드"
-    PROP_TITLE = "제목"
-    PROP_LYRICS = "가사"
-    PROP_AUDIO_URL = "음원URL"
+    PROP_TITLE = "title"
+    PROP_PLAYER_CODE = "player_code"
+    PROP_LYRICS = "lyrics"
+    PROP_AUDIO_FILE_NAME = "audio_file_name"
+    PROP_ID = "id"
 
     def to_properties(self, model: CheerSong) -> dict:
         return {
-            self.PROP_PLAYER_CODE: self._make_title(model.player_code),
-            self.PROP_TITLE: self._make_rich_text(model.title),
+            self.PROP_TITLE: self._make_title(model.title),
+            self.PROP_PLAYER_CODE: self._make_rich_text(model.player_code),
             self.PROP_LYRICS: self._make_rich_text(model.lyrics),
-            self.PROP_AUDIO_URL: self._make_rich_text(model.audio_url),
+            self.PROP_AUDIO_FILE_NAME: self._make_rich_text(model.audio_url),
         }
 
     def to_model(self, page: dict) -> CheerSong:
         props = page["properties"]
 
         return CheerSong(
-            id=0,
-            player_code=self._get_title(props, self.PROP_PLAYER_CODE),
-            title=self._get_rich_text(props, self.PROP_TITLE),
+            player_code=self._get_rich_text(props, self.PROP_PLAYER_CODE),
+            title=self._get_title(props, self.PROP_TITLE),
             lyrics=self._get_rich_text(props, self.PROP_LYRICS),
-            audio_url=self._get_rich_text(props, self.PROP_AUDIO_URL),
+            audio_url=self._get_rich_text(props, self.PROP_AUDIO_FILE_NAME),
         )

--- a/app/infrastructure/notion/mappers/player_mapper.py
+++ b/app/infrastructure/notion/mappers/player_mapper.py
@@ -3,14 +3,14 @@ from app.infrastructure.notion.mappers.base import BaseMapper
 
 class PlayerMapper(BaseMapper[Player]):
 
-    PROP_PLAYER_CODE = "선수코드"
-    PROP_TEAM_CODE = "팀코드"
-    PROP_NAME = "이름"
-    PROP_BACK_NUMBER = "등번호"
-    PROP_POSITION = "포지션"
-    PROP_BAT_THROW = "타격투구"
-    PROP_BATTING_ORDER = "타순"
-    PROP_IS_STARTER = "선발여부"
+    PROP_PLAYER_CODE = "player_code"
+    PROP_TEAM_CODE = "team_code"
+    PROP_NAME = "name"
+    PROP_BACK_NUMBER = "back_number"
+    PROP_POSITION = "position"
+    PROP_BAT_THROW = "bat_throw"
+    PROP_BATTING_ORDER = "batting_order"
+    PROP_IS_STARTER = "is_starter"
 
     def to_properties(self, model: Player) -> dict:
         properties = {

--- a/app/infrastructure/notion/mappers/team_mapper.py
+++ b/app/infrastructure/notion/mappers/team_mapper.py
@@ -5,14 +5,14 @@ from app.infrastructure.notion.mappers.base import BaseMapper
 
 class TeamMapper(BaseMapper[Team]):
 
-    PROP_TEAM_CODE = "팀코드"
-    PROP_TEAM_NAME = "팀명"
-    PROP_HAS_TODAY_GAME = "오늘경기여부"
-    PROP_OPPONENT_CODE = "상대팀코드"
-    PROP_STARTER_PITCHER = "선발투수"
-    PROP_LAST_GAME_DATE = "마지막경기일"
-    PROP_SEASON_ENDED = "시즌종료여부"
-    PROP_UPDATED_AT = "업데이트일시"
+    PROP_TEAM_CODE = "team_code"
+    PROP_TEAM_NAME = "team_name"
+    PROP_HAS_TODAY_GAME = "has_today_game"
+    PROP_OPPONENT_CODE = "opponent_team_code"
+    PROP_STARTER_PITCHER = "starter_pitcher_name"
+    PROP_LAST_GAME_DATE = "last_game_date"
+    PROP_SEASON_ENDED = "is_season_ended"
+    PROP_UPDATED_AT = "updated_at"
 
     def to_properties(self, model: Team) -> dict:
         properties = {

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,10 @@
 from fastapi import FastAPI
 
+from app.routers import crawl
+
 app = FastAPI(title="Cheerlot Crawler API")
+
+app.include_router(crawl.router)
 
 
 @app.get("/")

--- a/app/routers/crawl.py
+++ b/app/routers/crawl.py
@@ -1,0 +1,36 @@
+import logging
+from fastapi import APIRouter
+
+from app.services.crawl_service import CrawlService
+from app.schemas.crawl import GameCrawlResponse, TodayCrawlResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/crawl", tags=["crawl"])
+
+
+@router.post("/game/{game_id}", response_model=GameCrawlResponse)
+def crawl_game(game_id: str):
+    logger.info(f"API 호출 : /crawl/game/{game_id}")
+
+    service = CrawlService()
+    result = service.crawl_game(game_id)
+
+    return GameCrawlResponse.from_result(result)
+
+
+@router.post("/today", response_model=TodayCrawlResponse)
+def crawl_today():
+    logger.info("API 호출 : /crawl/today")
+
+    service = CrawlService()
+    results = service.crawl_today_games()
+
+    success_count = sum(1 for r in results if r.success)
+
+    return TodayCrawlResponse(
+        total_games=len(results),
+        success_count=success_count,
+        fail_count=len(results) - success_count,
+        results=[GameCrawlResponse.from_result(r) for r in results],
+    )

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,7 @@
+from app.schemas.crawl import CrawlResult, GameCrawlResponse, TodayCrawlResponse
+
+__all__ = [
+    "CrawlResult",
+    "GameCrawlResponse",
+    "TodayCrawlResponse",
+]

--- a/app/schemas/crawl.py
+++ b/app/schemas/crawl.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+from pydantic import BaseModel
+
+@dataclass
+class CrawlResult:
+    game_id: str
+    success: bool
+    home_team_code: str | None = None
+    away_team_code: str | None = None
+    players_saved: int = 0
+    error_message: str | None = None
+
+class GameCrawlResponse(BaseModel):
+    game_id: str
+    success: bool
+    home_team_code: str | None = None
+    away_team_code: str | None = None
+    players_saved: int = 0
+    error_message: str | None = None
+
+    @classmethod
+    def from_result(cls, result: CrawlResult) -> "GameCrawlResponse":
+        return cls(
+            game_id=result.game_id,
+            success=result.success,
+            home_team_code=result.home_team_code,
+            away_team_code=result.away_team_code,
+            players_saved=result.players_saved,
+            error_message=result.error_message,
+        )
+
+class TodayCrawlResponse(BaseModel):
+    total_games: int
+    success_count: int
+    fail_count: int
+    results: list[GameCrawlResponse]

--- a/app/services/crawl_service.py
+++ b/app/services/crawl_service.py
@@ -1,0 +1,172 @@
+import logging
+from datetime import date, datetime, timezone
+
+from app.models import Player, Team
+from app.repositories import PlayerRepository, TeamRepository
+from app.schemas.crawl import CrawlResult
+from app.services.crawler.schedule import ScheduleCrawlerService
+from app.services.crawler.lineup import LineupCrawlerService
+from app.services.crawler.parser import GameLineup, LineupPlayer
+
+logger = logging.getLogger(__name__)
+
+TEAM_NAMES = {
+    "hh": "한화 이글스",
+    "kt": "KT 위즈",
+    "lg": "LG 트윈스",
+    "nc": "NC 다이노스",
+    "ob": "두산 베어스",
+    "sk": "SSG 랜더스",
+    "ss": "삼성 라이온즈",
+    "wo": "키움 히어로즈",
+    "ht": "KIA 타이거즈",
+    "lt": "롯데 자이언츠",
+}
+
+
+class CrawlService:
+
+    def __init__(
+        self,
+        schedule_crawler: ScheduleCrawlerService | None = None,
+        lineup_crawler: LineupCrawlerService | None = None,
+        player_repository: PlayerRepository | None = None,
+        team_repository: TeamRepository | None = None,
+    ):
+        self._schedule_crawler = schedule_crawler or ScheduleCrawlerService()
+        self._lineup_crawler = lineup_crawler or LineupCrawlerService()
+        self._player_repository = player_repository or PlayerRepository()
+        self._team_repository = team_repository or TeamRepository()
+
+    def crawl_game(self, game_id: str) -> CrawlResult:
+        logger.info(f"게임 크롤링 시작 : {game_id}")
+
+        lineup = self._lineup_crawler.crawl_lineup(game_id)
+        if lineup is None:
+            logger.warning(f"라인업 조회 실패 또는 미발표 : {game_id}")
+            return CrawlResult(
+                game_id=game_id,
+                success=False,
+                error_message="라인업 조회 실패 또는 미발표",
+            )
+
+        saved_count = self._save_lineup(lineup)
+        self._update_teams(lineup)
+
+        logger.info(f"게임 크롤링 완료 : {game_id}, 저장된 선수 : {saved_count}명")
+        return CrawlResult(
+            game_id=game_id,
+            success=True,
+            home_team_code=lineup.home_team_code.lower(),
+            away_team_code=lineup.away_team_code.lower(),
+            players_saved=saved_count,
+        )
+
+    def crawl_today_games(self) -> list[CrawlResult]:
+        logger.info("오늘 경기 크롤링 시작")
+
+        game_ids = self._schedule_crawler.get_today_game_ids()
+        if not game_ids:
+            logger.info("오늘 예정된 경기 없음")
+            return []
+
+        logger.info(f"오늘 경기 {len(game_ids)}개 발견")
+
+        results = []
+        for game_id in game_ids:
+            try:
+                result = self.crawl_game(game_id)
+                results.append(result)
+            except Exception as e:
+                logger.exception(f"게임 처리 중 예외 발생 : {game_id}")
+                results.append(CrawlResult(
+                    game_id=game_id,
+                    success=False,
+                    error_message=str(e),
+                ))
+
+        success_count = sum(1 for r in results if r.success)
+        logger.info(f"오늘 경기 크롤링 완료 : {success_count} / {len(game_ids)} 성공")
+
+        return results
+
+    def _save_lineup(self, lineup: GameLineup) -> int:
+        saved_count = 0
+
+        for lineup_player in lineup.home_players:
+            player = self._convert_to_player(lineup_player, lineup.home_team_code)
+            self._player_repository.upsert(player)
+            saved_count += 1
+
+        for lineup_player in lineup.away_players:
+            player = self._convert_to_player(lineup_player, lineup.away_team_code)
+            self._player_repository.upsert(player)
+            saved_count += 1
+
+        return saved_count
+
+    def _convert_to_player(self, lineup_player: LineupPlayer, team_code: str) -> Player:
+        back_number_str = lineup_player.back_number or "00"
+        try:
+            back_number = int(back_number_str)
+        except ValueError:
+            back_number = 0
+
+        team_code_lower = team_code.lower()
+        player_code = f"{team_code_lower}{back_number_str}"
+
+        return Player(
+            player_code=player_code,
+            team_code=team_code_lower,
+            name=lineup_player.name,
+            back_number=back_number,
+            position=lineup_player.position,
+            bat_throw=lineup_player.bats_throws or "",
+            batting_order=lineup_player.bat_order,
+            is_starter=True,
+        )
+
+    def _update_teams(self, lineup: GameLineup) -> None:
+        home_team_code = lineup.home_team_code.lower()
+        away_team_code = lineup.away_team_code.lower()
+        game_date = lineup.game_date or date.today()
+        now = datetime.now(timezone.utc)
+
+        self._update_single_team(
+            team_code=home_team_code,
+            opponent_code=away_team_code,
+            starter_name=lineup.home_starter_name,
+            game_date=game_date,
+            updated_at=now,
+        )
+        logger.info(f"홈 팀 정보 업데이트 : {home_team_code}")
+
+        self._update_single_team(
+            team_code=away_team_code,
+            opponent_code=home_team_code,
+            starter_name=lineup.away_starter_name,
+            game_date=game_date,
+            updated_at=now,
+        )
+        logger.info(f"원정 팀 정보 업데이트 : {away_team_code}")
+
+    def _update_single_team(
+        self,
+        team_code: str,
+        opponent_code: str,
+        starter_name: str | None,
+        game_date: date,
+        updated_at: datetime,
+    ) -> None:
+        team_name = TEAM_NAMES.get(team_code, team_code)
+
+        team = Team(
+            team_code=team_code,
+            team_name=team_name,
+            has_today_game=True,
+            opponent_team_code=opponent_code,
+            starter_pitcher_name=starter_name,
+            last_game_date=game_date,
+            updated_at=updated_at,
+        )
+        self._team_repository.upsert(team)


### PR DESCRIPTION
  ### 변경 사항
  - `CrawlService`: 크롤링 통합 서비스 (선수 저장 + 팀 정보 최신화)
  - `GameLineup`: 선발투수명, 경기 날짜 필드 추가
  - `PreviewParser`: homeStarter/awayStarter, gdate 파싱 추가
  - 크롤링 API 라우터 추가

  ### 주요 기능
  - 크롤링 시 팀 정보 자동 최신화 (has_today_game, opponent_team_code,
  starter_pitcher_name, last_game_date)
  - player_code, team_code 소문자 변환 및 player_code에서 `_` 제거
  - team_name KBO 10개 팀 풀네임 매핑
  - last_game_date를 해당 경기 날짜로 설정

  ### API 엔드포인트
  - `POST /crawl/game/{game_id}`: 특정 경기 크롤링
  - `POST /crawl/today`: 오늘 경기 전체 크롤링

  Closes #10