### PR TITLE
✨ Feat: 라인업 크롤링 스케줄러 (#12)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,27 @@
+import logging
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
-from app.routers import crawl
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
 
-app = FastAPI(title="Cheerlot Crawler API")
+from app.routers import crawl
+from app.services.scheduler import SchedulerService
+
+scheduler_service = SchedulerService()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    scheduler_service.start()
+    yield
+    scheduler_service.shutdown()
+
+
+app = FastAPI(title="Cheerlot Crawler API", lifespan=lifespan)
 
 app.include_router(crawl.router)
 

--- a/app/services/crawler/schedule.py
+++ b/app/services/crawler/schedule.py
@@ -1,8 +1,9 @@
 import logging
 from app.services.crawler.client import NaverSportClient
-from app.services.crawler.parser import ScheduleParser
+from app.services.crawler.parser import ScheduleParser, PreviewParser, ScheduledGame
 
 logger = logging.getLogger(__name__)
+
 
 class ScheduleCrawlerService:
 
@@ -10,9 +11,11 @@ class ScheduleCrawlerService:
         self,
         client: NaverSportClient | None = None,
         parser: ScheduleParser | None = None,
+        preview_parser: PreviewParser | None = None,
     ):
         self.client = client or NaverSportClient()
         self.parser = parser or ScheduleParser()
+        self.preview_parser = preview_parser or PreviewParser()
 
     def get_today_game_ids(self) -> list[str]:
         logger.info("오늘 경기 일정 크롤링 시작")
@@ -26,3 +29,31 @@ class ScheduleCrawlerService:
         logger.info(f"오늘 경기 {len(game_ids)}개 발견 : {game_ids}")
 
         return game_ids
+
+    def get_today_games(self) -> list[ScheduledGame]:
+        logger.info("오늘 경기 일정 조회 (시간 정보 포함)")
+
+        game_ids = self.get_today_game_ids()
+        if not game_ids:
+            return []
+
+        games = []
+        for game_id in game_ids:
+            preview_data = self.client.get_game_preview(game_id)
+            if preview_data is None:
+                logger.warning(f"프리뷰 조회 실패: {game_id}")
+                continue
+
+            scheduled_game = self.preview_parser.parse_scheduled_game(game_id, preview_data)
+            if scheduled_game is None:
+                logger.warning(f"경기 시간 파싱 실패: {game_id}")
+                continue
+
+            games.append(scheduled_game)
+            logger.info(
+                f"  {scheduled_game.away_team_code} vs {scheduled_game.home_team_code} "
+                f"@ {scheduled_game.start_time.strftime('%H:%M')}"
+            )
+
+        logger.info(f"총 {len(games)}개 경기 조회 완료")
+        return games

--- a/app/services/scheduler/__init__.py
+++ b/app/services/scheduler/__init__.py
@@ -1,0 +1,3 @@
+from app.services.scheduler.scheduler_service import SchedulerService
+
+__all__ = ["SchedulerService"]

--- a/app/services/scheduler/scheduler_service.py
+++ b/app/services/scheduler/scheduler_service.py
@@ -1,0 +1,88 @@
+import logging
+from datetime import datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.date import DateTrigger
+
+from app.services.crawl_service import CrawlService
+from app.services.crawler.schedule import ScheduleCrawlerService
+
+logger = logging.getLogger(__name__)
+
+KST = ZoneInfo("Asia/Seoul")
+
+
+class SchedulerService:
+
+    def __init__(
+        self,
+        schedule_crawler: ScheduleCrawlerService | None = None,
+        crawl_service: CrawlService | None = None,
+    ):
+        self._schedule_crawler = schedule_crawler or ScheduleCrawlerService()
+        self._crawl_service = crawl_service or CrawlService()
+        self._scheduler = BackgroundScheduler(timezone=KST)
+
+    def start(self) -> None:
+        self._scheduler.add_job(
+            func=self._schedule_daily_games,
+            trigger=CronTrigger(hour=6, minute=0),
+            id="daily_schedule",
+            replace_existing=True,
+        )
+
+        self._scheduler.start()
+        logger.info("스케줄러 시작")
+
+        self._schedule_daily_games()
+
+    def shutdown(self) -> None:
+        self._scheduler.shutdown(wait=False)
+        logger.info("스케줄러 종료")
+
+    def _schedule_daily_games(self) -> None:
+        games = self._schedule_crawler.get_today_games()
+        if not games:
+            logger.info("오늘 경기 없음")
+            return
+
+        now = datetime.now(KST)
+        scheduled_count = 0
+
+        for game in games:
+            game_datetime = datetime.combine(now.date(), game.start_time, tzinfo=KST)
+            pre_crawl_datetime = game_datetime - timedelta(minutes=30)
+
+            # 경기 시작 30분 전
+            if pre_crawl_datetime > now:
+                self._scheduler.add_job(
+                    func=self._crawl_lineup,
+                    trigger=DateTrigger(run_date=pre_crawl_datetime),
+                    args=[game.game_id],
+                    id=f"pre_{game.game_id}",
+                    replace_existing=True,
+                )
+                scheduled_count += 1
+
+            # 경기 시작 시점
+            if game_datetime > now:
+                self._scheduler.add_job(
+                    func=self._crawl_lineup,
+                    trigger=DateTrigger(run_date=game_datetime),
+                    args=[game.game_id],
+                    id=f"start_{game.game_id}",
+                    replace_existing=True,
+                )
+                scheduled_count += 1
+
+        logger.info(f"{scheduled_count}개 크롤링 스케줄 등록 완료")
+
+    def _crawl_lineup(self, game_id: str) -> None:
+        try:
+            result = self._crawl_service.crawl_game(game_id)
+            if not result.success:
+                logger.warning(f"라인업 크롤링 실패: {game_id}")
+        except Exception:
+            logger.exception(f"라인업 크롤링 오류: {game_id}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 annotated-doc==0.0.4
+apscheduler==3.11.0
 annotated-types==0.7.0
 anyio==4.12.1
 certifi==2026.1.4


### PR DESCRIPTION
  ## 개요
  당일 경기 라인업을 자동으로 크롤링하는 스케줄러 추가

  ## 변경 사항
  - 매일 06:00 당일 경기 목록 자동 조회
  - 경기 시작 30분 전 라인업 크롤링
  - 경기 시작 시점 최종 라인업 크롤링
  - APScheduler 기반 백그라운드 스케줄링
  - 한국 시간(KST) 기준 동작

  ## 관련 이슈
  - closes #12
