### PR TITLE
✨ Feat: Discord Webhook 알림 기능 (#14)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ NOTION_API_KEY=your_notion_api_key
 NOTION_PLAYER_DB_ID=your_player_db_id
 NOTION_TEAM_DB_ID=your_team_db_id
 NOTION_CHEERSONG_DB_ID=your_cheersong_db_id
+DISCORD_WEBHOOK_URL=your_discord_webhook_url

--- a/app/config.py
+++ b/app/config.py
@@ -6,6 +6,7 @@ class Settings(BaseSettings):
     notion_player_db_id: str = ""
     notion_team_db_id: str = ""
     notion_cheersong_db_id: str = ""
+    discord_webhook_url: str = ""
 
     class Config:
         env_file = ".env"

--- a/app/constants.py
+++ b/app/constants.py
@@ -1,0 +1,16 @@
+from zoneinfo import ZoneInfo
+
+KST = ZoneInfo("Asia/Seoul")
+
+TEAM_NAMES = {
+    "hh": "한화 이글스",
+    "kt": "KT 위즈",
+    "lg": "LG 트윈스",
+    "nc": "NC 다이노스",
+    "ob": "두산 베어스",
+    "sk": "SSG 랜더스",
+    "ss": "삼성 라이온즈",
+    "wo": "키움 히어로즈",
+    "ht": "KIA 타이거즈",
+    "lt": "롯데 자이언츠",
+}

--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -1,9 +1,11 @@
 from app.repositories.team_repository import TeamRepository
+from app.repositories.base import UpsertResult
 from app.repositories.player_repository import PlayerRepository
 from app.repositories.cheersong_repository import CheerSongRepository
 
 __all__ = [
     "TeamRepository",
     "PlayerRepository",
+    "UpsertResult",
     "CheerSongRepository",
 ]

--- a/app/repositories/base.py
+++ b/app/repositories/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Generic, TypeVar
 
 from pydantic import BaseModel
@@ -7,6 +8,12 @@ from app.infrastructure.notion import NotionClient
 from app.infrastructure.notion.mappers import BaseMapper
 
 T = TypeVar("T", bound=BaseModel)
+
+
+@dataclass
+class UpsertResult:
+    created: bool
+    response: dict
 
 class BaseRepository(ABC, Generic[T]):
 

--- a/app/repositories/player_repository.py
+++ b/app/repositories/player_repository.py
@@ -1,6 +1,6 @@
 from app.config import settings
 from app.models import Player
-from app.repositories.base import BaseRepository
+from app.repositories.base import BaseRepository, UpsertResult
 from app.infrastructure.notion.mappers import BaseMapper, PlayerMapper
 
 class PlayerRepository(BaseRepository[Player]):
@@ -42,7 +42,7 @@ class PlayerRepository(BaseRepository[Player]):
         }
         return self.find_by_filter(filter)
 
-    def upsert(self, player: Player) -> dict:
+    def upsert(self, player: Player) -> UpsertResult:
         filter = {
             "property": PlayerMapper.PROP_PLAYER_CODE,
             "title": {"equals": player.player_code},
@@ -50,6 +50,8 @@ class PlayerRepository(BaseRepository[Player]):
         pages = self._client.query_database(self.database_id, filter=filter)
 
         if pages:
-            return self.update(pages[0]["id"], player)
-        return self.create(player)
+            response = self.update(pages[0]["id"], player)
+            return UpsertResult(created=False, response=response)
+        response = self.create(player)
+        return UpsertResult(created=True, response=response)
     

--- a/app/repositories/team_repository.py
+++ b/app/repositories/team_repository.py
@@ -1,6 +1,6 @@
 from app.config import settings
 from app.models import Team
-from app.repositories.base import BaseRepository
+from app.repositories.base import BaseRepository, UpsertResult
 from app.infrastructure.notion.mappers import BaseMapper, TeamMapper
 
 class TeamRepository(BaseRepository[Team]):
@@ -27,7 +27,7 @@ class TeamRepository(BaseRepository[Team]):
         }
         return self.find_by_filter(filter)
 
-    def upsert(self, team: Team) -> dict:
+    def upsert(self, team: Team) -> UpsertResult:
         filter = {
             "property": TeamMapper.PROP_TEAM_CODE,
             "title": {"equals": team.team_code},
@@ -35,5 +35,7 @@ class TeamRepository(BaseRepository[Team]):
         pages = self._client.query_database(self.database_id, filter=filter)
 
         if pages:
-            return self.update(pages[0]["id"], team)
-        return self.create(team)
+            response = self.update(pages[0]["id"], team)
+            return UpsertResult(created=False, response=response)
+        response = self.create(team)
+        return UpsertResult(created=True, response=response)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,7 +1,8 @@
-from app.schemas.crawl import CrawlResult, GameCrawlResponse, TodayCrawlResponse
+from app.schemas.crawl import CrawlResult, NewPlayerInfo, GameCrawlResponse, TodayCrawlResponse
 
 __all__ = [
     "CrawlResult",
+    "NewPlayerInfo",
     "GameCrawlResponse",
     "TodayCrawlResponse",
 ]

--- a/app/schemas/crawl.py
+++ b/app/schemas/crawl.py
@@ -1,5 +1,15 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pydantic import BaseModel
+
+
+@dataclass
+class NewPlayerInfo:
+    player_code: str
+    name: str
+    team_code: str
+    back_number: int
+    position: str
+
 
 @dataclass
 class CrawlResult:
@@ -9,6 +19,7 @@ class CrawlResult:
     away_team_code: str | None = None
     players_saved: int = 0
     error_message: str | None = None
+    new_players: list[NewPlayerInfo] = field(default_factory=list)
 
 class GameCrawlResponse(BaseModel):
     game_id: str

--- a/app/services/crawl_service.py
+++ b/app/services/crawl_service.py
@@ -1,27 +1,15 @@
 import logging
 from datetime import date, datetime, timezone
 
+from app.constants import TEAM_NAMES
 from app.models import Player, Team
 from app.repositories import PlayerRepository, TeamRepository
-from app.schemas.crawl import CrawlResult
+from app.schemas.crawl import CrawlResult, NewPlayerInfo
 from app.services.crawler.schedule import ScheduleCrawlerService
 from app.services.crawler.lineup import LineupCrawlerService
 from app.services.crawler.parser import GameLineup, LineupPlayer
 
 logger = logging.getLogger(__name__)
-
-TEAM_NAMES = {
-    "hh": "한화 이글스",
-    "kt": "KT 위즈",
-    "lg": "LG 트윈스",
-    "nc": "NC 다이노스",
-    "ob": "두산 베어스",
-    "sk": "SSG 랜더스",
-    "ss": "삼성 라이온즈",
-    "wo": "키움 히어로즈",
-    "ht": "KIA 타이거즈",
-    "lt": "롯데 자이언츠",
-}
 
 
 class CrawlService:
@@ -50,16 +38,21 @@ class CrawlService:
                 error_message="라인업 조회 실패 또는 미발표",
             )
 
-        saved_count = self._save_lineup(lineup)
+        saved_count, new_players = self._save_lineup(lineup)
         self._update_teams(lineup)
 
-        logger.info(f"게임 크롤링 완료 : {game_id}, 저장된 선수 : {saved_count}명")
+        logger.info(
+            f"게임 크롤링 완료 : {game_id}, "
+            f"저장된 선수 : {saved_count}명, "
+            f"신규 선수 : {len(new_players)}명"
+        )
         return CrawlResult(
             game_id=game_id,
             success=True,
             home_team_code=lineup.home_team_code.lower(),
             away_team_code=lineup.away_team_code.lower(),
             players_saved=saved_count,
+            new_players=new_players,
         )
 
     def crawl_today_games(self) -> list[CrawlResult]:
@@ -90,20 +83,33 @@ class CrawlService:
 
         return results
 
-    def _save_lineup(self, lineup: GameLineup) -> int:
+    def _save_lineup(self, lineup: GameLineup) -> tuple[int, list[NewPlayerInfo]]:
         saved_count = 0
+        new_players: list[NewPlayerInfo] = []
 
-        for lineup_player in lineup.home_players:
-            player = self._convert_to_player(lineup_player, lineup.home_team_code)
-            self._player_repository.upsert(player)
-            saved_count += 1
+        all_entries = [
+            (lineup.home_players, lineup.home_team_code),
+            (lineup.away_players, lineup.away_team_code),
+        ]
 
-        for lineup_player in lineup.away_players:
-            player = self._convert_to_player(lineup_player, lineup.away_team_code)
-            self._player_repository.upsert(player)
-            saved_count += 1
+        for players, team_code in all_entries:
+            for lineup_player in players:
+                player = self._convert_to_player(lineup_player, team_code)
+                upsert_result = self._player_repository.upsert(player)
+                saved_count += 1
+                if upsert_result.created:
+                    new_players.append(self._to_new_player_info(player))
 
-        return saved_count
+        return saved_count, new_players
+
+    def _to_new_player_info(self, player: Player) -> NewPlayerInfo:
+        return NewPlayerInfo(
+            player_code=player.player_code,
+            name=player.name,
+            team_code=player.team_code,
+            back_number=player.back_number,
+            position=player.position,
+        )
 
     def _convert_to_player(self, lineup_player: LineupPlayer, team_code: str) -> Player:
         back_number_str = lineup_player.back_number or "00"

--- a/app/services/discord_notifier.py
+++ b/app/services/discord_notifier.py
@@ -1,0 +1,130 @@
+import logging
+from datetime import datetime
+
+import httpx
+
+from app.config import settings
+from app.constants import KST, TEAM_NAMES
+from app.schemas.crawl import CrawlResult, NewPlayerInfo
+from app.services.crawler.parser import ScheduledGame
+
+logger = logging.getLogger(__name__)
+
+
+class DiscordNotifier:
+
+    def __init__(self, webhook_url: str | None = None, timeout: float = 10.0):
+        self._webhook_url = webhook_url or settings.discord_webhook_url
+        self._timeout = timeout
+
+    def _is_enabled(self) -> bool:
+        return bool(self._webhook_url)
+
+    def send_daily_schedule(self, games: list[ScheduledGame]) -> None:
+        if not self._is_enabled():
+            return
+
+        now = datetime.now(KST)
+        date_str = now.strftime("%Y-%m-%d (%a)")
+
+        if not games:
+            embed = self._build_embed(
+                title="KBO 오늘의 경기",
+                description=f"{date_str}\n\n경기 없음",
+                color=0x808080,
+            )
+        else:
+            lines = []
+            for game in games:
+                away = TEAM_NAMES.get(game.away_team_code, game.away_team_code)
+                home = TEAM_NAMES.get(game.home_team_code, game.home_team_code)
+                time_str = game.start_time.strftime("%H:%M")
+                lines.append(f"**{away}** vs **{home}** - {time_str}")
+
+            embed = self._build_embed(
+                title="KBO 오늘의 경기",
+                description=f"{date_str}\n\n" + "\n".join(lines),
+                color=0x3498DB,
+                footer=f"총 {len(games)}경기",
+            )
+
+        self._send(embeds=[embed])
+
+    def send_lineup_result(self, result: CrawlResult) -> None:
+        if not self._is_enabled():
+            return
+
+        if result.success:
+            home = TEAM_NAMES.get(result.home_team_code or "", result.home_team_code or "")
+            away = TEAM_NAMES.get(result.away_team_code or "", result.away_team_code or "")
+            embed = self._build_embed(
+                title="라인업 크롤링 완료",
+                description=(
+                    f"**{away}** vs **{home}**\n\n"
+                    f"저장된 선수: {result.players_saved}명\n"
+                    f"신규 선수: {len(result.new_players)}명"
+                ),
+                color=0x2ECC71,
+                footer=f"Game ID: {result.game_id}",
+            )
+        else:
+            embed = self._build_embed(
+                title="라인업 크롤링 실패",
+                description=(
+                    f"Game ID: `{result.game_id}`\n"
+                    f"오류: {result.error_message or '알 수 없는 오류'}"
+                ),
+                color=0xE74C3C,
+            )
+
+        self._send(embeds=[embed])
+
+    def send_new_players(self, new_players: list[NewPlayerInfo]) -> None:
+        if not self._is_enabled() or not new_players:
+            return
+
+        lines = []
+        for p in new_players:
+            team = TEAM_NAMES.get(p.team_code, p.team_code)
+            lines.append(f"**{p.name}** ({team}) #{p.back_number} {p.position}")
+
+        embed = self._build_embed(
+            title="신규 선수 등록",
+            description="\n".join(lines),
+            color=0xF39C12,
+            footer=f"총 {len(new_players)}명 신규 등록",
+        )
+
+        self._send(embeds=[embed])
+
+    def _build_embed(
+        self,
+        title: str,
+        description: str,
+        color: int,
+        footer: str | None = None,
+    ) -> dict:
+        embed = {
+            "title": title,
+            "description": description,
+            "color": color,
+            "timestamp": datetime.now(KST).isoformat(),
+        }
+        if footer:
+            embed["footer"] = {"text": footer}
+        return embed
+
+    def _send(self, embeds: list[dict]) -> None:
+        payload = {
+            "username": "Cheerlot Crawler",
+            "embeds": embeds,
+        }
+        try:
+            with httpx.Client(timeout=self._timeout) as client:
+                response = client.post(self._webhook_url, json=payload)
+                response.raise_for_status()
+            logger.info(f"Discord 알림 전송 완료: {embeds[0].get('title', '')}")
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Discord 웹훅 전송 실패 (HTTP {e.response.status_code})")
+        except httpx.RequestError as e:
+            logger.error(f"Discord 웹훅 연결 실패: {e}")

--- a/app/services/scheduler/scheduler_service.py
+++ b/app/services/scheduler/scheduler_service.py
@@ -1,17 +1,17 @@
 import logging
 from datetime import datetime, time, timedelta
-from zoneinfo import ZoneInfo
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
 
+from app.constants import KST
+from app.schemas.crawl import CrawlResult
 from app.services.crawl_service import CrawlService
 from app.services.crawler.schedule import ScheduleCrawlerService
+from app.services.discord_notifier import DiscordNotifier
 
 logger = logging.getLogger(__name__)
-
-KST = ZoneInfo("Asia/Seoul")
 
 
 class SchedulerService:
@@ -20,9 +20,11 @@ class SchedulerService:
         self,
         schedule_crawler: ScheduleCrawlerService | None = None,
         crawl_service: CrawlService | None = None,
+        discord_notifier: DiscordNotifier | None = None,
     ):
         self._schedule_crawler = schedule_crawler or ScheduleCrawlerService()
         self._crawl_service = crawl_service or CrawlService()
+        self._discord_notifier = discord_notifier or DiscordNotifier()
         self._scheduler = BackgroundScheduler(timezone=KST)
 
     def start(self) -> None:
@@ -44,6 +46,8 @@ class SchedulerService:
 
     def _schedule_daily_games(self) -> None:
         games = self._schedule_crawler.get_today_games()
+        self._discord_notifier.send_daily_schedule(games)
+
         if not games:
             logger.info("오늘 경기 없음")
             return
@@ -82,7 +86,16 @@ class SchedulerService:
     def _crawl_lineup(self, game_id: str) -> None:
         try:
             result = self._crawl_service.crawl_game(game_id)
+            self._discord_notifier.send_lineup_result(result)
+            if result.new_players:
+                self._discord_notifier.send_new_players(result.new_players)
             if not result.success:
                 logger.warning(f"라인업 크롤링 실패: {game_id}")
-        except Exception:
+        except Exception as e:
             logger.exception(f"라인업 크롤링 오류: {game_id}")
+            error_result = CrawlResult(
+                game_id=game_id,
+                success=False,
+                error_message=str(e),
+            )
+            self._discord_notifier.send_lineup_result(error_result)

--- a/tests/test_discord_notifier.py
+++ b/tests/test_discord_notifier.py
@@ -1,0 +1,175 @@
+from datetime import time
+from unittest.mock import patch, MagicMock
+
+import httpx
+import pytest
+
+from app.schemas.crawl import CrawlResult, NewPlayerInfo
+from app.services.crawler.parser import ScheduledGame
+from app.services.discord_notifier import DiscordNotifier
+
+
+@pytest.fixture
+def notifier():
+    return DiscordNotifier(webhook_url="https://discord.com/api/webhooks/test")
+
+
+@pytest.fixture
+def disabled_notifier():
+    return DiscordNotifier(webhook_url="")
+
+
+class TestIsEnabled:
+    def test_enabled_with_url(self, notifier):
+        assert notifier._is_enabled() is True
+
+    def test_disabled_without_url(self, disabled_notifier):
+        assert disabled_notifier._is_enabled() is False
+
+
+class TestSendDailySchedule:
+    @patch("app.services.discord_notifier.httpx.Client")
+    def test_sends_games(self, mock_client_cls, notifier):
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = MagicMock(status_code=204)
+
+        games = [
+            ScheduledGame(
+                game_id="20260211OBHT0",
+                start_time=time(18, 30),
+                home_team_code="ht",
+                away_team_code="ob",
+            ),
+        ]
+
+        notifier.send_daily_schedule(games)
+
+        mock_client.post.assert_called_once()
+        payload = mock_client.post.call_args[1]["json"]
+        assert payload["username"] == "Cheerlot Crawler"
+        assert len(payload["embeds"]) == 1
+        assert "KBO 오늘의 경기" in payload["embeds"][0]["title"]
+        assert "두산 베어스" in payload["embeds"][0]["description"]
+        assert "KIA 타이거즈" in payload["embeds"][0]["description"]
+
+    @patch("app.services.discord_notifier.httpx.Client")
+    def test_sends_no_games(self, mock_client_cls, notifier):
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = MagicMock(status_code=204)
+
+        notifier.send_daily_schedule([])
+
+        payload = mock_client.post.call_args[1]["json"]
+        assert "경기 없음" in payload["embeds"][0]["description"]
+
+    def test_skips_when_disabled(self, disabled_notifier):
+        with patch("app.services.discord_notifier.httpx.Client") as mock:
+            disabled_notifier.send_daily_schedule([])
+            mock.assert_not_called()
+
+
+class TestSendLineupResult:
+    @patch("app.services.discord_notifier.httpx.Client")
+    def test_sends_success(self, mock_client_cls, notifier):
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = MagicMock(status_code=204)
+
+        result = CrawlResult(
+            game_id="20260211OBHT0",
+            success=True,
+            home_team_code="ht",
+            away_team_code="ob",
+            players_saved=18,
+            new_players=[
+                NewPlayerInfo("ht99", "김민수", "ht", 99, "투수"),
+            ],
+        )
+
+        notifier.send_lineup_result(result)
+
+        payload = mock_client.post.call_args[1]["json"]
+        embed = payload["embeds"][0]
+        assert "크롤링 완료" in embed["title"]
+        assert embed["color"] == 0x2ECC71
+        assert "18명" in embed["description"]
+        assert "신규 선수: 1명" in embed["description"]
+
+    @patch("app.services.discord_notifier.httpx.Client")
+    def test_sends_failure(self, mock_client_cls, notifier):
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = MagicMock(status_code=204)
+
+        result = CrawlResult(
+            game_id="20260211OBHT0",
+            success=False,
+            error_message="라인업 조회 실패",
+        )
+
+        notifier.send_lineup_result(result)
+
+        payload = mock_client.post.call_args[1]["json"]
+        embed = payload["embeds"][0]
+        assert "크롤링 실패" in embed["title"]
+        assert embed["color"] == 0xE74C3C
+
+
+class TestSendNewPlayers:
+    @patch("app.services.discord_notifier.httpx.Client")
+    def test_sends_new_players(self, mock_client_cls, notifier):
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = MagicMock(status_code=204)
+
+        new_players = [
+            NewPlayerInfo("ht99", "김민수", "ht", 99, "투수"),
+            NewPlayerInfo("ob07", "이준호", "ob", 7, "외야수"),
+        ]
+
+        notifier.send_new_players(new_players)
+
+        payload = mock_client.post.call_args[1]["json"]
+        embed = payload["embeds"][0]
+        assert "신규 선수 등록" in embed["title"]
+        assert embed["color"] == 0xF39C12
+        assert "김민수" in embed["description"]
+        assert "이준호" in embed["description"]
+        assert "2명" in embed["footer"]["text"]
+
+    def test_skips_empty_list(self, notifier):
+        with patch("app.services.discord_notifier.httpx.Client") as mock:
+            notifier.send_new_players([])
+            mock.assert_not_called()
+
+
+class TestErrorHandling:
+    @patch("app.services.discord_notifier.httpx.Client")
+    def test_http_error_does_not_raise(self, mock_client_cls, notifier):
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Bad Request", request=MagicMock(), response=mock_response,
+        )
+        mock_client.post.return_value = mock_response
+
+        notifier.send_daily_schedule([])
+
+    @patch("app.services.discord_notifier.httpx.Client")
+    def test_request_error_does_not_raise(self, mock_client_cls, notifier):
+        mock_client = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_client.post.side_effect = httpx.RequestError("Connection failed")
+
+        notifier.send_daily_schedule([])


### PR DESCRIPTION
## 개요
크롤링 실행 시 결과를 Discord 채널로 전송하고, 신규 선수 발견 시 별도 알림을 보내는 기능 추가

## 변경 사항
- Discord Webhook 기반 알림 서비스 (`DiscordNotifier`) 구현
  - 일일 경기 일정 알림 (06:00 스케줄 조회 시)
  - 라인업 크롤링 결과 알림 (성공/실패)
  - 신규 선수 등록 알림 (Notion DB에 없는 선수 발견 시)
- `UpsertResult` 도입으로 Repository의 create/update 구분 가능
- `TEAM_NAMES`, `KST` 상수를 `constants.py`로 분리하여 순환 참조 방지
- 스케줄러 예외 발생 시에도 Discord 오류 알림 전송
- 11개 유닛 테스트 추가

## 관련 이슈
- closes #14
