### PR TITLE
🐛 Fix: NotionClient에 재시도 로직 및 타임아웃 처리 추가 (#26)

### DIFF
--- a/app/infrastructure/notion/client.py
+++ b/app/infrastructure/notion/client.py
@@ -1,8 +1,14 @@
+import logging
+import time
+
 import httpx
-from notion_client import Client
-from notion_client.errors import APIResponseError
 
 from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT = 30.0
+DEFAULT_MAX_RETRIES = 3
 
 
 class NotionClientError(Exception):
@@ -13,9 +19,15 @@ class NotionClient:
     BASE_URL = "https://api.notion.com/v1"
     NOTION_VERSION = "2022-06-28"
 
-    def __init__(self, api_key: str | None = None):
+    def __init__(
+        self,
+        api_key: str | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+    ):
         self._api_key = api_key or settings.notion_api_key
-        self._client = Client(auth=self._api_key)
+        self._timeout = timeout
+        self._max_retries = max_retries
 
     def _get_headers(self) -> dict:
         return {
@@ -24,49 +36,66 @@ class NotionClient:
             "Content-Type": "application/json",
         }
 
+    def _request_with_retry(
+        self,
+        method: str,
+        url: str,
+        **kwargs,
+    ) -> dict:
+        last_exception = None
+
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                with httpx.Client(timeout=self._timeout) as client:
+                    response = client.request(
+                        method, url, headers=self._get_headers(), **kwargs
+                    )
+                    response.raise_for_status()
+                    return response.json()
+            except httpx.HTTPStatusError as e:
+                raise NotionClientError(
+                    f"Notion API failed (HTTP {e.response.status_code}): {e.response.text}"
+                ) from e
+            except httpx.RequestError as e:
+                last_exception = e
+                logger.warning(
+                    f"Notion API 요청 실패 ({attempt}/{self._max_retries}): {url} - {e}"
+                )
+                if attempt < self._max_retries:
+                    time.sleep(1)
+
+        raise NotionClientError(
+            f"Notion API 최종 실패 ({self._max_retries}회 재시도 모두 실패): {url}"
+        ) from last_exception
+
     def query_database(
         self,
         database_id: str,
         filter: dict | None = None,
         sorts: list[dict] | None = None,
     ) -> list[dict]:
-        try:
-            body = {}
-            if filter:
-                body["filter"] = filter
-            if sorts:
-                body["sorts"] = sorts
+        body = {}
+        if filter:
+            body["filter"] = filter
+        if sorts:
+            body["sorts"] = sorts
 
-            url = f"{self.BASE_URL}/databases/{database_id}/query"
-            response = httpx.post(url, headers=self._get_headers(), json=body)
-            response.raise_for_status()
-            return response.json().get("results", [])
-        except httpx.HTTPStatusError as e:
-            raise NotionClientError(f"Database query failed: {e.response.text}") from e
+        url = f"{self.BASE_URL}/databases/{database_id}/query"
+        result = self._request_with_retry("POST", url, json=body)
+        return result.get("results", [])
 
     def create_page(self, database_id: str, properties: dict) -> dict:
-        try:
-            return self._client.pages.create(
-                parent={"database_id": database_id},
-                properties=properties,
-            )
-        except APIResponseError as e:
-            raise NotionClientError(f"Page create failed: {str(e)}") from e
+        url = f"{self.BASE_URL}/pages"
+        body = {
+            "parent": {"database_id": database_id},
+            "properties": properties,
+        }
+        return self._request_with_retry("POST", url, json=body)
 
     def update_page(self, page_id: str, properties: dict) -> dict:
-        try:
-            return self._client.pages.update(
-                page_id=page_id,
-                properties=properties,
-            )
-        except APIResponseError as e:
-            raise NotionClientError(f"Page update failed: {str(e)}") from e
+        url = f"{self.BASE_URL}/pages/{page_id}"
+        return self._request_with_retry("PATCH", url, json={"properties": properties})
 
     def archive_page(self, page_id: str) -> dict:
-        try:
-            return self._client.pages.update(
-                page_id=page_id,
-                archived=True,
-            )
-        except APIResponseError as e:
-            raise NotionClientError(f"Page archive failed: {str(e)}") from e
+        url = f"{self.BASE_URL}/pages/{page_id}"
+        return self._request_with_retry("PATCH", url, json={"archived": True})

--- a/tests/test_notion_client.py
+++ b/tests/test_notion_client.py
@@ -1,0 +1,121 @@
+from unittest.mock import patch, MagicMock
+
+import httpx
+import pytest
+
+from app.infrastructure.notion.client import NotionClient, NotionClientError
+
+
+class TestRequestWithRetry:
+
+    @patch("app.infrastructure.notion.client.httpx.Client")
+    def test_success_on_first_attempt(self, mock_client_cls):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": [{"id": "page1"}]}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.request.return_value = mock_response
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = NotionClient(api_key="test-key")
+        result = client.query_database("db-id", filter={"property": "Name"})
+
+        assert result == [{"id": "page1"}]
+
+    @patch("app.infrastructure.notion.client.time.sleep")
+    @patch("app.infrastructure.notion.client.httpx.Client")
+    def test_retry_on_timeout_then_success(self, mock_client_cls, mock_sleep):
+        success_response = MagicMock()
+        success_response.json.return_value = {"results": []}
+        success_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.request.side_effect = [
+            httpx.ReadTimeout("The read operation timed out", request=MagicMock()),
+            success_response,
+        ]
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = NotionClient(api_key="test-key", max_retries=3)
+        result = client.query_database("db-id")
+
+        assert result == []
+        mock_sleep.assert_called_once_with(1)
+
+    @patch("app.infrastructure.notion.client.time.sleep")
+    @patch("app.infrastructure.notion.client.httpx.Client")
+    def test_all_retries_fail_raises_error(self, mock_client_cls, mock_sleep):
+        mock_client = MagicMock()
+        mock_client.request.side_effect = httpx.ReadTimeout(
+            "The read operation timed out", request=MagicMock()
+        )
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = NotionClient(api_key="test-key", max_retries=3)
+
+        with pytest.raises(NotionClientError, match="최종 실패"):
+            client.query_database("db-id")
+
+        assert mock_sleep.call_count == 2
+
+    @patch("app.infrastructure.notion.client.httpx.Client")
+    def test_http_status_error_no_retry(self, mock_client_cls):
+        error_response = MagicMock()
+        error_response.status_code = 400
+        error_response.text = "Bad Request"
+
+        mock_client = MagicMock()
+        mock_client.request.side_effect = httpx.HTTPStatusError(
+            "Bad Request", request=MagicMock(), response=error_response
+        )
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = NotionClient(api_key="test-key", max_retries=3)
+
+        with pytest.raises(NotionClientError, match="HTTP 400"):
+            client.query_database("db-id")
+
+        assert mock_client.request.call_count == 1
+
+
+class TestCreatePage:
+
+    @patch("app.infrastructure.notion.client.httpx.Client")
+    def test_create_page_success(self, mock_client_cls):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "new-page"}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.request.return_value = mock_response
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = NotionClient(api_key="test-key")
+        result = client.create_page("db-id", {"Name": {"title": [{"text": {"content": "Test"}}]}})
+
+        assert result == {"id": "new-page"}
+
+
+class TestUpdatePage:
+
+    @patch("app.infrastructure.notion.client.httpx.Client")
+    def test_update_page_success(self, mock_client_cls):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "page-1"}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.request.return_value = mock_response
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = NotionClient(api_key="test-key")
+        result = client.update_page("page-1", {"Status": {"checkbox": True}})
+
+        assert result == {"id": "page-1"}


### PR DESCRIPTION
## 개요
동시 크롤링 시 Notion API 타임아웃(`httpx.ReadTimeout`)이 미처리되어 크롤링이 크래시되던 문제 수정

## 변경 사항
- `notion_client` SDK 제거, 모든 메서드를 직접 httpx 호출로 통일
- 공통 `_request_with_retry()` 메서드 추가 (최대 3회 재시도, 30초 타임아웃)
- HTTP 에러(400/404)는 즉시 실패, 타임아웃/네트워크 에러만 재시도
- 단위 테스트 6개 추가

## 관련 이슈
- closes #26